### PR TITLE
Setup Deployement workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,48 @@
+# Automate releases of new app versions
+name: release-please
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          release-type: node
+          package-name: graasp-app-excalidraw
+          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"docs","section":"Documentation","hidden":false},{"type":"test","section":"Tests","hidden":false}]'
+
+      - uses: actions/checkout@v3
+
+      # creates minor and major tags that follow the latest release
+      - name: Tag major and minor versions
+        uses: jacobsvante/tag-major-minor-action@v0.1
+        if: ${{ steps.release.outputs.release_created }}
+        with:
+          major: ${{ steps.release.outputs.major }}
+          minor: ${{ steps.release.outputs.minor }}
+
+      # put created tag in an env variable to be sent to the dispatch
+      - name: Set tag
+        if: ${{ steps.release.outputs.release_created }}
+        id: set-tag
+        run: |
+          REPOSITORY=$(echo '${{ github.repository }}')
+          TAG=$(echo '${{ steps.release.outputs.tag_name }}')
+          JSON=$(jq -c --null-input --arg repository "$REPOSITORY" --arg tag "$TAG" '{"repository": $repository, "tag": $tag}')
+          echo "json=$JSON" >> $GITHUB_OUTPUT
+
+      # Trigger an 'on: repository_dispatch' workflow to run in graasp-deploy repository
+      - name: Push tag to Graasp Deploy (Staging)
+        if: ${{ steps.release.outputs.release_created }}
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: graasp/graasp-deploy
+          event-type: update-staging-version
+          client-payload: ${{steps.set-tag.outputs.json}}


### PR DESCRIPTION
This PR adds all the deployment workflows needed to deploy an app on graasp.

Required steps:
- [ ] add tag creation workflow using release-please
- [ ] add dev deployement workflow
- [ ] add stage deployement workflow triggered by repository_dispatch
- [ ] add prod deployement workflow triggered by repository_dispatch
- [ ] add a cypress/build workflow to ensure app is working. Should be triggered on each push.
- [ ] generate an app id
  - [ ] set the id as `REACT_APP_ID` in the repo secrets
  - [ ] send it to @pyphilia to be added to the DB in all 3 envs so that the app shows up in the app dropdown 
- [ ] add any necessary secrets that the app needs

@swouf I can start with some of these, and adapt to your needs

closes #2 