### PR TITLE
fix: rename sentry dsn env variable name

### DIFF
--- a/src/config/sentry.ts
+++ b/src/config/sentry.ts
@@ -26,7 +26,7 @@ export const generateSentryConfig = (): SentryConfigType => {
   }
 
   return {
-    dsn: (!window.Cypress && process.env.SENTRY_DSN) || '',
+    dsn: (!window.Cypress && process.env.REACT_APP_SENTRY_DSN) || '',
     environment: SENTRY_ENVIRONMENT,
     tracesSampleRate: SENTRY_TRACE_SAMPLE_RATE,
   };


### PR DESCRIPTION
This PR fixes a problem where the environnement variable for sentry does not have the right name. For reference [here](https://github.com/graasp/graasp-deploy/blob/17adebbcdd94c2003a024d9e218def0c816b738d/.github/workflows/cdeployment-s3-apps.yml#L85) you can see how it is supplied during the build process.

closes #8 